### PR TITLE
Add vitest setup and currency utils tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -110,7 +111,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.5.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/__tests__/currency.test.ts
+++ b/server/__tests__/currency.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatCZK, parseCZK } from '../utils';
+
+describe('formatCZK', () => {
+  it('formats positive numbers with thousand separators', () => {
+    expect(formatCZK(123456789)).toBe('1\u00A0234\u00A0567\u00A0CZK');
+  });
+
+  it('formats zero correctly', () => {
+    expect(formatCZK(0)).toBe('0\u00A0CZK');
+  });
+
+  it('formats negative numbers by flooring', () => {
+    expect(formatCZK(-12345)).toBe('-124\u00A0CZK');
+  });
+});
+
+describe('parseCZK', () => {
+  it('parses formatted currency strings', () => {
+    expect(parseCZK('1\u00A0234\u00A0CZK')).toBe(123400);
+  });
+
+  it('handles strings with commas and spaces', () => {
+    expect(parseCZK('1,234 CZK')).toBe(123400);
+  });
+
+  it('returns 0 for invalid input', () => {
+    expect(parseCZK('invalid')).toBe(0);
+    expect(parseCZK('')).toBe(0);
+  });
+
+  it('ignores negative sign when parsing', () => {
+    expect(parseCZK('-123 CZK')).toBe(12300);
+  });
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "server/__tests__/**/*"],
+  "exclude": ["node_modules", "build", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['server/__tests__/**/*.test.ts'],
+  }
+});


### PR DESCRIPTION
## Summary
- set up vitest configuration and tsconfig
- add tests for `formatCZK` and `parseCZK`
- expose `npm test` script

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688919481f5883278e6d10d98b1a936f