### PR TITLE
Fix currency formatting for cent values

### DIFF
--- a/client/src/pages/customer-home.tsx
+++ b/client/src/pages/customer-home.tsx
@@ -80,7 +80,7 @@ export default function CustomerHome() {
                   <div className="h-12 w-32 bg-white/20 rounded-2xl animate-pulse"></div>
                 ) : (
                   <h2 className="text-4xl font-bold tracking-tight">
-                    {formatCurrency((wallet?.balanceCents || 0) / 100)}
+                    {formatCurrency(wallet?.balanceCents || 0)}
                   </h2>
                 )}
               </div>
@@ -94,13 +94,13 @@ export default function CustomerHome() {
                 <div>
                   <p className="text-white/70 text-sm">Total Bonus Earned</p>
                   <p className="text-lg font-semibold">
-                    {formatCurrency((wallet.bonusGrantedTotalCents || 0) / 100)}
+                    {formatCurrency(wallet.bonusGrantedTotalCents || 0)}
                   </p>
                 </div>
                 <div className="text-right">
                   <p className="text-white/70 text-sm">Available Credit</p>
                   <p className="text-lg font-semibold">
-                    {formatCurrency((wallet.balanceCents || 0) / 100)}
+                    {formatCurrency(wallet.balanceCents || 0)}
                   </p>
                 </div>
               </div>
@@ -213,7 +213,7 @@ export default function CustomerHome() {
                       transaction.amountCents > 0 ? 'text-sage' : 'text-foreground'
                     }`}>
                       {transaction.amountCents > 0 ? '+' : ''}
-                      {formatCurrency(Math.abs(transaction.amountCents) / 100)}
+                      {formatCurrency(Math.abs(transaction.amountCents))}
                     </span>
                   </div>
                 ))}

--- a/client/src/utils/currency.ts
+++ b/client/src/utils/currency.ts
@@ -1,8 +1,9 @@
 export function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('cs-CZ', {
-    style: 'currency',
-    currency: 'CZK',
+  const czk = Math.floor(amount / 100);
+  return new Intl.NumberFormat("cs-CZ", {
+    style: "currency",
+    currency: "CZK",
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
-  }).format(amount);
+  }).format(czk);
 }


### PR DESCRIPTION
## Summary
- update `formatCurrency` to convert cents to CZK
- update customer home page to pass cent amounts directly

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6889192f2654832792f23fd633917764