### PR TITLE
Fix typo in server/vite.ts comment

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -52,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- fix the typo in the Vite server comment

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68891917fc7083278fa1d7ff70e2a92a